### PR TITLE
Fix ITF14 checksum implementation

### DIFF
--- a/modules/encodings/itf14.js
+++ b/modules/encodings/itf14.js
@@ -23,7 +23,7 @@ class ITF14 extends ITF {
       result += Number(this.code[i]) * (3 - (i % 2) * 2)
     }
 
-    return 10 - (result % 10)
+    return Math.ceil(result / 10) * 10 - result;
   }
 }
 


### PR DESCRIPTION
The sum of digits \* their position value (1 or 3) sometimes lands on a multiple of 10 (e.g. 110).  The original implementation (`return 10 - (result % 10)`) would yield a checksum digit of `10`, where it should yield a `0`. Rounding up to the nearest 10 and subtracting by the result is the correct formula, as per [GS1's Specifications](http://www.gs1.org/how-calculate-check-digit-manually).
